### PR TITLE
Fix for Issue #2 [Overlapping of graph date intervals (cases.html) ]

### DIFF
--- a/script/genomics.py
+++ b/script/genomics.py
@@ -1395,9 +1395,13 @@ def main():
 
     df_cases_r_data['date'] = pd.to_datetime(df_cases_r_data['date'])
 
-    df_cases_r_data = df_cases_r_data.groupby(['location', pd.Grouper(key='date', freq='2W')]).agg(
-        {'r': 'mean'}).reset_index()
+#     df_cases_r_data = df_cases_r_data.groupby(['location', pd.Grouper(key='date', freq='2W')]).agg(
+#         {'r': 'mean'}).reset_index()
 
+    df_cases_r_data = df_cases_r_data.groupby(['location', pd.Grouper(key='date', freq='2W',label='left',offset="6D")]).agg(
+    {'r': 'mean'}).reset_index()
+    df_cases_r_data['date']=df_cases_r_data['date']+pd.DateOffset(days=7)
+    
     print("Merge cases")
     df_cases_r_data = pd.merge(df_cases_r_data, df_cases_data, on=['location', 'date'], how='outer', sort=True)
     df_cases_r_data = pd.merge(df_cases_r_data, iso_list, on=['location'], how='outer', sort=False)


### PR DESCRIPTION
As described in the issue #2 , the line plots consisted of overlapping date intervals in the period preceding 2023-01-02 to 2023-01-15. 

After the migration of the primary data source from **JHU's COVID-19  data** to **WHO's data**, the **merging of the df_cases_r_data and df_cases_data dataframes** (in line 1402 of the genomics.py file) were leading to the extra date periods. 

After performing a groupby on location (for a 2 week period) on **JHU's data**, in the df_cases_data file, the date periods started from '2020-03-08','2020-03-22',....... all the way to .......,'2023-03-05', '2023-03-19' as seen in the commit made on March 11 2023. https://raw.githubusercontent.com/3dgiordano/SARS-CoV-2-Variants/515d9a19ff7c9c85b9a7247107402a04dfc79eab/data/cases_r.csv

The df_cases_r_data dataframe consisted of date periods from '2020-04-05','2020-04-19',..... all the way to .....,'2022-12-25','2023-01-08'.

Hence, the merge of the df_cases_data and df_cases_r_data was working perfectly as they have similar dates.

However, after the migration to WHO data, the the date periods started from '2020-01-05','2020-01-19',....... all the way to .......,'2023-03-12', '2023-03-26'. This leads to issues while merging with df_cases_r_data, as there are different dates in df_cases_data and df_cases_r_data.

Through this pull request, I have made a small change in order to offset the start date in df_cases_r_data by a week in order to have the dates in both  df_cases_data and df_cases_r_data in sync that would lead to the resolution of the issue.
